### PR TITLE
Add HTML calculator with duty cycle column and appliance database

### DIFF
--- a/calculadora_consumo.html
+++ b/calculadora_consumo.html
@@ -1,0 +1,129 @@
+<!-- === Calculadora de Consumo y Potencia con Ciclo de Trabajo === -->
+<style>
+    table { width:100%; border-collapse: collapse; }
+    th, td { border:1px solid #ccc; padding:6px; text-align:center; }
+    .btn { margin:5px 0; padding:6px 10px; cursor:pointer; }
+    .btn-remove { background-color:#e74c3c; color:#fff; }
+    .btn-add { background-color:#3498db; color:#fff; }
+    .summary { margin-top:20px; border:1px solid #ccc; padding:10px; }
+</style>
+
+<div id="calcLoad">
+    <h3>Calculadora de Artefactos</h3>
+    <table id="loadTable">
+        <thead>
+            <tr>
+                <th></th>
+                <th>Nombre</th>
+                <th>¿Simultáneo?</th>
+                <th>Cantidad</th>
+                <th>Potencia (W)</th>
+                <th>Pico (W)</th>
+                <th>Ciclo de trabajo</th>
+                <th>Horas/día</th>
+                <th>Energía diaria (Wh)</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+    <button class="btn btn-add" onclick="addRow()">Añadir artefacto</button>
+    <button class="btn btn-add" onclick="addFromDatabase()">Agregar artefacto desde base de datos</button>
+
+    <div class="summary">
+        <p>Equipos simultáneos: <span id="simultaneousCount">0</span></p>
+        <p>Potencia total simultánea (W): <span id="totalPower">0</span></p>
+        <p>Pico de potencia total (W): <span id="totalPeak">0</span></p>
+        <p>Consumo diario total (Wh): <span id="totalEnergy">0</span></p>
+    </div>
+</div>
+
+<script>
+let loads = [];
+
+// Base de datos con artefactos comunes
+const deviceDB = [
+  { name: "Heladera", power: 150, peak: 600, cycle: 0.3, hours: 24 },
+  { name: "Televisor LED 40\"", power: 80, peak: 100, cycle: 1, hours: 4 },
+  { name: "Computadora de escritorio", power: 250, peak: 300, cycle: 1, hours: 8 },
+  { name: "Lámpara LED 9W", power: 9, peak: 9, cycle: 1, hours: 5 },
+  { name: "Lavadora", power: 500, peak: 1000, cycle: 0.1, hours: 1 }
+];
+
+function addRow(data) {
+    const tableBody = document.querySelector('#loadTable tbody');
+    const idx = loads.length;
+
+    loads.push({
+        name: data?.name || '',
+        simultaneous: data?.simultaneous || false,
+        qty: data?.qty || 1,
+        power: data?.power || 0,
+        peak: data?.peak || 0,
+        cycle: data?.cycle ?? 1,
+        hours: data?.hours || 0
+    });
+
+    const row = document.createElement('tr');
+    row.setAttribute('data-idx', idx);
+    row.innerHTML = `
+        <td><button class="btn btn-remove" onclick="removeRow(${idx})">X</button></td>
+        <td><input type="text" value="${loads[idx].name}" oninput="update(${idx}, 'name', this.value)"></td>
+        <td><input type="checkbox" ${loads[idx].simultaneous? 'checked':''} onchange="update(${idx}, 'simultaneous', this.checked)"></td>
+        <td><input type="number" min="0" value="${loads[idx].qty}" oninput="update(${idx}, 'qty', parseFloat(this.value)||0)"></td>
+        <td><input type="number" min="0" value="${loads[idx].power}" oninput="update(${idx}, 'power', parseFloat(this.value)||0)"></td>
+        <td><input type="number" min="0" value="${loads[idx].peak}" oninput="update(${idx}, 'peak', parseFloat(this.value)||0)"></td>
+        <td><input type="number" min="0" max="1" step="0.01" value="${loads[idx].cycle}" oninput="update(${idx}, 'cycle', parseFloat(this.value)||0)"></td>
+        <td><input type="number" min="0" value="${loads[idx].hours}" oninput="update(${idx}, 'hours', parseFloat(this.value)||0)"></td>
+        <td><span id="energy-${idx}">0</span></td>
+    `;
+    tableBody.appendChild(row);
+    update(idx, null, null); // calcula energía inicial
+}
+
+function removeRow(idx) {
+    loads[idx] = null;
+    const tr = document.querySelector(`tr[data-idx="${idx}"]`);
+    if (tr) tr.remove();
+    calcTotals();
+}
+
+function update(idx, field, value) {
+    if (!loads[idx]) return;
+    if (field) loads[idx][field] = value;
+    const energy = loads[idx].qty * loads[idx].power * loads[idx].cycle * loads[idx].hours;
+    document.getElementById(`energy-${idx}`).innerText = energy.toFixed(0);
+    calcTotals();
+}
+
+function calcTotals() {
+    let simultaneousCount = 0;
+    let totalPower = 0;
+    let totalPeak = 0;
+    let totalEnergy = 0;
+
+    loads.forEach(item => {
+        if (!item) return;
+        if (item.simultaneous) simultaneousCount += item.qty;
+        totalPower += item.simultaneous ? item.qty * item.power : 0;
+        const peakVal = item.peak > 0 ? item.peak : item.power;
+        totalPeak = Math.max(totalPeak, item.qty * peakVal);
+        totalEnergy += item.qty * item.power * item.cycle * item.hours;
+    });
+
+    document.getElementById('simultaneousCount').innerText = simultaneousCount;
+    document.getElementById('totalPower').innerText = totalPower.toFixed(0);
+    document.getElementById('totalPeak').innerText = totalPeak.toFixed(0);
+    document.getElementById('totalEnergy').innerText = totalEnergy.toFixed(0);
+}
+
+function addFromDatabase() {
+    const list = deviceDB.map((d,i) => `${i+1}. ${d.name}`).join('\n');
+    const choice = parseInt(prompt('Seleccione un artefacto:\n'+list));
+    if (!isNaN(choice) && deviceDB[choice-1]) {
+        addRow(deviceDB[choice-1]);
+    }
+}
+
+// Fila inicial
+addRow();
+</script>


### PR DESCRIPTION
## Summary
- add HTML-based appliance consumption calculator
- include duty cycle column in energy formula
- provide sample appliance database and button to insert from database

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a50eb28e18832c930a7fb06f3481c9